### PR TITLE
refactor: General cleanup, alignment with `std`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,6 +7,9 @@ pub fn build(b: *std.Build) !void {
     const module = b.addModule("network", .{
         .root_source_file = b.path("network.zig"),
     });
+    if (target.result.os.tag == .windows) {
+        module.link_libc = true;
+    }
 
     var test_runner = b.addTest(.{
         .root_source_file = b.path("testsuite.zig"),

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -19,7 +19,12 @@ test "Connect to an echo server" {
     try network.init();
     defer network.deinit();
 
-    const sock = try network.connectToHost(std.heap.page_allocator, "tcpbin.com", 4242, .tcp);
+    const sock = try network.connectToHost(
+        std.heap.page_allocator,
+        "tcpbin.com",
+        4242,
+        .tcp,
+    );
     defer sock.close();
 
     const msg = "Hi from socket!\n";


### PR DESCRIPTION
Reduce custom types and functions, preferring existing definitions in `std`. Standardize line lengths to idiomatic ~80~ 100 characters. Clean up of some `TODO` comments.

The `socket` function remains separate from the `std.posix.socket` implementation; however, the `std` implementation translates POSIX `SOCK.NONBLOCK`/`SOCK.CLOEXEC` to the Windows-specific implementation using `ioctl`, and thus there appears to be reasonable potential to integrate `SOCK.DGRAM` handling directly in `std`. This would enable using `std.posix.socket` directly.

Resolves #44.