### PR TITLE
docs: Rename LICENCE typo to LICENSE, update years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Felix Queißner
+Copyright (c) 2020-2024 Felix Queißner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Minor typo in license file name spelling (at least not matching content of "MIT License" at top of file). Also updated years to be a range as per [FSF recommendation](https://www.gnu.org/licenses/gpl-howto.en.html) under the consideration that commits have been published every year since 2020.