### PR TITLE
Fix Windows polling

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -824,7 +824,7 @@ pub const SocketEvent = struct {
 /// A set of sockets that can be used to query socket readiness.
 /// This is similar to `select()´ or `poll()` and provides a way to
 /// create non-blocking socket I/O.
-/// This is intented to be used with `waitForSocketEvents()`.
+/// This is intended to be used with `waitForSocketEvents()`.
 pub const SocketSet = struct {
     const Self = @This();
 

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -7,7 +7,7 @@ test "Get endpoint list" {
     try network.init();
     defer network.deinit();
 
-    const endpoint_list = try network.getEndpointList(std.heap.page_allocator, "google.com", 80);
+    const endpoint_list = try network.getEndpointList(std.testing.allocator, "google.com", 80);
     defer endpoint_list.deinit();
 
     for (endpoint_list.endpoints) |endpt| {
@@ -19,14 +19,60 @@ test "Connect to an echo server" {
     try network.init();
     defer network.deinit();
 
-    const sock = try network.connectToHost(std.heap.page_allocator, "tcpbin.com", 4242, .tcp);
+    const sock = try network.connectToHost(std.testing.allocator, "tcpbin.com", 4242, .tcp);
     defer sock.close();
 
     const msg = "Hi from socket!\n";
     try sock.writer().writeAll(msg);
 
     var buf: [128]u8 = undefined;
-    std.debug.print("Echo: {s}", .{buf[0..try sock.reader().readAll(buf[0..msg.len])]});
+    const read_size = try sock.reader().readAll(buf[0..msg.len]);
+    try std.testing.expectEqualSlices(u8, msg, buf[0..read_size]);
+    std.debug.print("Echo: {s}", .{buf[0..read_size]});
+}
+
+test "Echo server readiness" {
+    try network.init();
+    defer network.deinit();
+
+    const sock = try network.connectToHost(
+        std.testing.allocator,
+        "tcpbin.com",
+        4242,
+        .tcp,
+    );
+    defer sock.close();
+
+    var write_set = try network.SocketSet.init(std.testing.allocator);
+    defer write_set.deinit();
+    var read_set = try network.SocketSet.init(std.testing.allocator);
+    defer read_set.deinit();
+
+    try write_set.add(sock, .{ .write = true, .read = false });
+    defer write_set.remove(sock);
+
+    try read_set.add(sock, .{ .write = false, .read = true });
+    defer read_set.remove(sock);
+
+    const msg = "Hi from socket!\n";
+
+    if (try network.waitForSocketEvent(&write_set, 5 * std.time.ns_per_s) != 1) {
+        return error.InvalidSocketWriteWait;
+    }
+    if (!write_set.isReadyWrite(sock)) {
+        return error.SocketNotReadyForWrite;
+    }
+    try sock.writer().writeAll(msg);
+
+    if (try network.waitForSocketEvent(&read_set, 5 * std.time.ns_per_s) != 1) {
+        return error.InvalidSocketReadWait;
+    }
+    if (!read_set.isReadyRead(sock)) {
+        return error.SocketNotReadyForRead;
+    }
+    var buf: [128]u8 = undefined;
+    const read_size = try sock.reader().readAll(buf[0..msg.len]);
+    try std.testing.expectEqualSlices(u8, msg, buf[0..read_size]);
 }
 
 test "UDP timeout" {
@@ -39,7 +85,7 @@ test "UDP timeout" {
         .address = .{ .ipv4 = network.Address.IPv4.init(1, 1, 1, 1) },
         .port = 53,
     });
-    try sock.setReadTimeout(3000000); // 3 seconds
+    try sock.setReadTimeout(3 * std.time.us_per_s);
     try std.testing.expectError(error.WouldBlock, sock.reader().readByte());
 }
 


### PR DESCRIPTION
Noticed that #88 broke Windows `SocketSet` functionality, but it wasn't caught by any tests. Added coverage for `SocketSet` functions and polling. Also added one additional check to the "Connect to an echo server" test (expecting that the read message from the socket should match the write message), and changed allocator usage to `std.testing.allocator` instead of the previous `page_allocator`. Reverted pertinent polling-related parts of #88.