### PR TITLE
Failed compilation for zig0.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,15 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+#     According to https://github.com/goto-bus-stop/setup-zig#setup-zig:
+#     This GitHub Action is unmaintained. Please use mlugg/setup-zig instead.
+#      - name: Setup Zig
+#        uses: goto-bus-stop/setup-zig@v1
+#        with:
+#          version: master
+
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v1
+        uses: mlugg/setup-zig@v1
         with:
           version: master
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,10 @@ jobs:
 #        # if: ${{ matrix.platform != 'windows-latest' }}
 #        run: |
 #          zig build discovery-examples
-#
-#      - name: Compile and test udp broadcast
-#        run: |
-#          zig build udp-broadcast
+
+      - name: Compile and test udp broadcast
+        run: |
+          zig build udp-broadcast
       
       - name: Compile and test ntp client
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
       #        run: |
       #          zig build async-examples
 
-#      - name: Compile and test udp
-#        # if: ${{ matrix.platform != 'windows-latest' }}
-#        run: |
-#          zig build udp-examples
+      - name: Compile and test udp
+        # if: ${{ matrix.platform != 'windows-latest' }}
+        run: |
+          zig build udp-examples
 
       - name: Compile and test discovery
         # if: ${{ matrix.platform != 'windows-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,28 +33,28 @@ jobs:
         with:
           version: master
 
-      - name: Compile and test synchronous
-        run: |
-          zig build test install sync-examples
+#      - name: Compile and test synchronous
+#        run: |
+#          zig build test install sync-examples
 
       #      - name: Compile and test asynchronous
       #        # if: ${{ matrix.platform != 'windows-latest' }}
       #        run: |
       #          zig build async-examples
 
-      - name: Compile and test udp
-        # if: ${{ matrix.platform != 'windows-latest' }}
-        run: |
-          zig build udp-examples
-
-      - name: Compile and test discovery
-        # if: ${{ matrix.platform != 'windows-latest' }}
-        run: |
-          zig build discovery-examples
-
-      - name: Compile and test udp broadcast
-        run: |
-          zig build udp-broadcast
+#      - name: Compile and test udp
+#        # if: ${{ matrix.platform != 'windows-latest' }}
+#        run: |
+#          zig build udp-examples
+#
+#      - name: Compile and test discovery
+#        # if: ${{ matrix.platform != 'windows-latest' }}
+#        run: |
+#          zig build discovery-examples
+#
+#      - name: Compile and test udp broadcast
+#        run: |
+#          zig build udp-broadcast
       
       - name: Compile and test ntp client
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,11 @@ jobs:
 #        # if: ${{ matrix.platform != 'windows-latest' }}
 #        run: |
 #          zig build udp-examples
-#
-#      - name: Compile and test discovery
-#        # if: ${{ matrix.platform != 'windows-latest' }}
-#        run: |
-#          zig build discovery-examples
+
+      - name: Compile and test discovery
+        # if: ${{ matrix.platform != 'windows-latest' }}
+        run: |
+          zig build discovery-examples
 
       - name: Compile and test udp broadcast
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: master
+          cache: false
 
       - name: Compile and test synchronous
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: '0 5 * * *' # run at 5 AM UTC, continous integration against master branch
+    - cron: '0 5 * * *' # run at 5 AM UTC, continuous integration against master branch
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           version: master
 
-#      - name: Compile and test synchronous
-#        run: |
-#          zig build test install sync-examples
+      - name: Compile and test synchronous
+        run: |
+          zig build test install sync-examples
 
       #      - name: Compile and test asynchronous
       #        # if: ${{ matrix.platform != 'windows-latest' }}
@@ -45,7 +45,7 @@ jobs:
       - name: Compile and test udp
         # if: ${{ matrix.platform != 'windows-latest' }}
         run: |
-          zig build udp-examples
+          zig build udp-examples        
 
       - name: Compile and test discovery
         # if: ${{ matrix.platform != 'windows-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
     branches: [master]
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC, continous integration against master branch
-  workflow_dispatch:
 
 jobs:
   build:
@@ -33,7 +32,6 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: master
-          cache: false
 
       - name: Compile and test synchronous
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,14 @@
 name: CI
 
 on:
+
   push:
     branches: [master]
   pull_request:
     branches: [master]
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC, continous integration against master branch
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-out/
 /.zig-cache/
+.idea/

--- a/network.zig
+++ b/network.zig
@@ -1415,23 +1415,23 @@ const windows = struct {
         tv_usec: c_long,
     };
 
-    const addrinfo = extern struct {
-        flags: i32,
-        family: i32,
-        socktype: i32,
-        protocol: i32,
-        addrlen: std.posix.socklen_t,
-        canonname: ?[*:0]u8,
-        addr: ?*std.posix.sockaddr,
-        next: ?*addrinfo,
-    };
+    // const addrinfo = extern struct {
+    //     flags: i32,
+    //     family: i32,
+    //     socktype: i32,
+    //     protocol: i32,
+    //     addrlen: std.posix.socklen_t,
+    //     canonname: ?[*:0]u8,
+    //     addr: ?*std.posix.sockaddr,
+    //     next: ?*addrinfo,
+    // };
 
     const funcs = struct {
         extern "ws2_32" fn recvfrom(s: ws2_32.SOCKET, buf: [*c]u8, len: c_int, flags: c_int, from: [*c]std.posix.sockaddr, fromlen: [*c]std.posix.socklen_t) callconv(std.os.windows.WINAPI) c_int;
         extern "ws2_32" fn select(nfds: c_int, readfds: ?*anyopaque, writefds: ?*anyopaque, exceptfds: ?*anyopaque, timeout: [*c]const timeval) callconv(std.os.windows.WINAPI) c_int;
         extern "ws2_32" fn __WSAFDIsSet(arg0: ws2_32.SOCKET, arg1: [*]u8) c_int;
         extern "ws2_32" fn getaddrinfo(nodename: [*:0]const u8, servicename: [*:0]const u8, hints: *const posix.addrinfo, result: **posix.addrinfo) callconv(std.os.windows.WINAPI) c_int;
-        extern "ws2_32" fn freeaddrinfo(res: *addrinfo) callconv(std.os.windows.WINAPI) void;
+        extern "ws2_32" fn freeaddrinfo(res: *posix.addrinfo) callconv(std.os.windows.WINAPI) void;
     };
 
     // TODO: This can be removed in favor of upstream Zig `std.posix.socket` if the
@@ -1523,8 +1523,8 @@ const windows = struct {
     fn getaddrinfo(
         name: [*:0]const u8,
         port: [*:0]const u8,
-        hints: *const addrinfo,
-        result: *?*addrinfo,
+        hints: *const posix.addrinfo,
+        result: *?*posix.addrinfo,
     ) GetAddrInfoError!void {
         const rc = funcs.getaddrinfo(name, port, hints, @ptrCast(result));
         if (rc != 0)

--- a/network.zig
+++ b/network.zig
@@ -1260,8 +1260,8 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        var AI_NUMERICSERV:i32 = 0;
-        const ai: AI = @bitCast(AI_NUMERICSERV);
+        var AI_NUMERICSERV: i32 = 0;
+        var ai: AI = @bitCast(AI_NUMERICSERV);
         ai.NUMERICSERV = true;
         AI_NUMERICSERV = @bitCast(ai);
 

--- a/network.zig
+++ b/network.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const os = @import("os");
 const builtin = @import("builtin");
-const native_os = builtin.os.tag;
 const posix = std.posix;
 
 comptime {
@@ -1278,7 +1277,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
             .next = null,
         };
 
-        var res: ?*addrinfo = undefined;
+        var res: ?*posix.addrinfo = undefined;
         try getaddrinfo_fn(name_c.ptr, @ptrCast(port_c.ptr), &hints, &res);
         defer if (res) |r| freeaddrinfo_fn(r);
 

--- a/network.zig
+++ b/network.zig
@@ -1260,12 +1260,10 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        const ai: AI = .{};
-        const nc = ai.NUMERICSERV;
-        @memset(&ai, 0);
-        ai.NUMERICSERV = nc;
-
-        const AI_NUMERICSERV: i32 = @bitCast(ai);
+        var AI_NUMERICSERV:i32 = 0;
+        const ai: AI = @bitCast(AI_NUMERICSERV);
+        ai.NUMERICSERV = true;
+        AI_NUMERICSERV = @bitCast(ai);
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);

--- a/network.zig
+++ b/network.zig
@@ -1260,10 +1260,10 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        const NUMERICSERV =  if (is_windows) i32 else std.c.AI__struct_1605;
+        const NUMERICSERV = if (is_windows) i32 else std.c.AI.AI__struct_1605;
         var AI_NUMERICSERV: NUMERICSERV = 0;
         var ai: AI = @bitCast(AI_NUMERICSERV);
-        ai.NUMERICSERV = true;
+        ai.NUMERICSERV = false;
         AI_NUMERICSERV = @bitCast(ai);
 
         const name_c = try allocator.dupeZ(u8, name);

--- a/network.zig
+++ b/network.zig
@@ -1260,11 +1260,11 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        const NUMERICSERV = if (is_windows) i32 else std.c.AI.AI__struct_1605;
-        var AI_NUMERICSERV: NUMERICSERV = 0;
-        var ai: AI = @bitCast(AI_NUMERICSERV);
-        ai.NUMERICSERV = false;
-        AI_NUMERICSERV = @bitCast(ai);
+        const FLAGS = if (is_windows) i32 else std.c.AI.AI__struct_1605;
+        var flags: FLAGS = 0;
+        var ai: AI = @bitCast(flags);
+        ai.NUMERICSERV = true;
+        flags = @bitCast(ai);
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);
@@ -1273,7 +1273,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         defer allocator.free(port_c);
 
         const hints = addrinfo{
-            .flags = AI_NUMERICSERV,
+            .flags = flags  ,
             .family = std.posix.AF.UNSPEC,
             .socktype = std.posix.SOCK.STREAM,
             .protocol = std.posix.IPPROTO.TCP,

--- a/network.zig
+++ b/network.zig
@@ -1258,7 +1258,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
     if (builtin.link_libc or is_windows) {
         const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
         const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
-        const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
+        //const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);
@@ -1283,7 +1283,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
 
         const addr_count = blk: {
             var count: usize = 0;
-            var it: ?*addrinfo = res;
+            var it: ?*posix.addrinfo = res;
             while (it) |info| : (it = info.next) {
                 if (info.addr != null) {
                     count += 1;
@@ -1293,7 +1293,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         };
         result.endpoints = try arena.alloc(EndPoint, addr_count);
 
-        var it: ?*addrinfo = res;
+        var it: ?*posix.addrinfo = res;
         var i: usize = 0;
         while (it) |info| : (it = info.next) {
             const sockaddr = info.addr orelse continue;

--- a/network.zig
+++ b/network.zig
@@ -1430,7 +1430,7 @@ const windows = struct {
         extern "ws2_32" fn recvfrom(s: ws2_32.SOCKET, buf: [*c]u8, len: c_int, flags: c_int, from: [*c]std.posix.sockaddr, fromlen: [*c]std.posix.socklen_t) callconv(std.os.windows.WINAPI) c_int;
         extern "ws2_32" fn select(nfds: c_int, readfds: ?*anyopaque, writefds: ?*anyopaque, exceptfds: ?*anyopaque, timeout: [*c]const timeval) callconv(std.os.windows.WINAPI) c_int;
         extern "ws2_32" fn __WSAFDIsSet(arg0: ws2_32.SOCKET, arg1: [*]u8) c_int;
-        extern "ws2_32" fn getaddrinfo(nodename: [*:0]const u8, servicename: [*:0]const u8, hints: *const addrinfo, result: **addrinfo) callconv(std.os.windows.WINAPI) c_int;
+        extern "ws2_32" fn getaddrinfo(nodename: [*:0]const u8, servicename: [*:0]const u8, hints: *const posix.addrinfo, result: **posix.addrinfo) callconv(std.os.windows.WINAPI) c_int;
         extern "ws2_32" fn freeaddrinfo(res: *addrinfo) callconv(std.os.windows.WINAPI) void;
     };
 

--- a/network.zig
+++ b/network.zig
@@ -552,8 +552,8 @@ pub const Socket = struct {
         std.debug.assert(read == null or read.? != 0);
         const micros = read orelse 0;
         var opt = if (is_windows) @as(u32, @divTrunc(micros, 1000)) else std.posix.timeval{
-            .tv_sec = @intCast(@divTrunc(micros, std.time.us_per_s)),
-            .tv_usec = @intCast(@mod(micros, std.time.us_per_s)),
+            .sec = @intCast(@divTrunc(micros, std.time.us_per_s)),
+            .usec = @intCast(@mod(micros, std.time.us_per_s)),
         };
         try std.posix.setsockopt(
             self.internal,

--- a/network.zig
+++ b/network.zig
@@ -1258,7 +1258,6 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
     if (builtin.link_libc or is_windows) {
         const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
         const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
-        //const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);
@@ -1414,17 +1413,6 @@ const windows = struct {
         tv_sec: c_long,
         tv_usec: c_long,
     };
-
-    // const addrinfo = extern struct {
-    //     flags: i32,
-    //     family: i32,
-    //     socktype: i32,
-    //     protocol: i32,
-    //     addrlen: std.posix.socklen_t,
-    //     canonname: ?[*:0]u8,
-    //     addr: ?*std.posix.sockaddr,
-    //     next: ?*addrinfo,
-    // };
 
     const funcs = struct {
         extern "ws2_32" fn recvfrom(s: ws2_32.SOCKET, buf: [*c]u8, len: c_int, flags: c_int, from: [*c]std.posix.sockaddr, fromlen: [*c]std.posix.socklen_t) callconv(std.os.windows.WINAPI) c_int;

--- a/network.zig
+++ b/network.zig
@@ -1259,12 +1259,14 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
+        const NUMERICSERV = 8;
+
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        const FLAGS = if (is_windows) i32 else std.c.AI.AI__struct_1605;
+                const FLAGS = if (is_windows) i32 else std.c.AI.AI__struct_1605;
         var flags: FLAGS = 0;
         var ai: AI = @bitCast(flags);
         ai.NUMERICSERV = true;
-        flags = @bitCast(ai);
+        flags = NUMERICSERV;//@bitCast(ai);
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);

--- a/network.zig
+++ b/network.zig
@@ -1260,7 +1260,8 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
-        var AI_NUMERICSERV: i32 = 0;
+        const NUMERICSERV =  if (is_windows) i32 else std.c.AI__struct_1605;
+        var AI_NUMERICSERV: NUMERICSERV = 0;
         var ai: AI = @bitCast(AI_NUMERICSERV);
         ai.NUMERICSERV = true;
         AI_NUMERICSERV = @bitCast(ai);

--- a/network.zig
+++ b/network.zig
@@ -1265,7 +1265,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         @memset(&ai, 0);
         ai.NUMERICSERV = nc;
 
-        const AI_NUMERICSERV: i32 = ai;
+        const AI_NUMERICSERV: i32 = @bitCast(ai);
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);

--- a/network.zig
+++ b/network.zig
@@ -1259,10 +1259,8 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
-        const AI_NUMERICSERV: bool = if (is_windows)
-            windows.ws2_32.AI.NUMERICSERV
-        else
-            std.c.AI.NUMERICSERV;
+        const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
+        const ai: AI = .{};
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);
@@ -1271,7 +1269,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         defer allocator.free(port_c);
 
         const hints = addrinfo{
-            .flags = AI_NUMERICSERV,
+            .flags = ai.NUMERICSERV,
             .family = std.posix.AF.UNSPEC,
             .socktype = std.posix.SOCK.STREAM,
             .protocol = std.posix.IPPROTO.TCP,

--- a/network.zig
+++ b/network.zig
@@ -1257,8 +1257,8 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
     errdefer result.arena.deinit();
 
     if (builtin.link_libc or is_windows) {
-        // const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
-        // const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
+        const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
+        const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const name_c = try allocator.dupeZ(u8, name);
@@ -1278,11 +1278,9 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
             .next = null,
         };
 
-        const sys = if (native_os == .windows) windows.ws2_32 else posix.system;
-
         var res: ?*addrinfo = undefined;
-        try sys.getaddrinfo(name_c.ptr, @ptrCast(port_c.ptr), &hints, &res);
-        defer if (res) |r| sys.freeaddrinfo(r);
+        try getaddrinfo_fn(name_c.ptr, @ptrCast(port_c.ptr), &hints, &res);
+        defer if (res) |r| freeaddrinfo_fn(r);
 
         const addr_count = blk: {
             var count: usize = 0;

--- a/network.zig
+++ b/network.zig
@@ -1257,8 +1257,8 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
     errdefer result.arena.deinit();
 
     if (builtin.link_libc or is_windows) {
-        const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
-        const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
+        // const getaddrinfo_fn = if (is_windows) windows.getaddrinfo else libc_getaddrinfo;
+        // const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
         const name_c = try allocator.dupeZ(u8, name);
@@ -1278,9 +1278,11 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
             .next = null,
         };
 
+        const sys = if (native_os == .windows) windows.ws2_32 else posix.system;
+
         var res: ?*addrinfo = undefined;
-        try getaddrinfo_fn(name_c.ptr, @ptrCast(port_c.ptr), &hints, &res);
-        defer if (res) |r| freeaddrinfo_fn(r);
+        try sys.getaddrinfo(name_c.ptr, @ptrCast(port_c.ptr), &hints, &res);
+        defer if (res) |r| sys.freeaddrinfo(r);
 
         const addr_count = blk: {
             var count: usize = 0;

--- a/network.zig
+++ b/network.zig
@@ -1261,6 +1261,11 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
 
         const AI = if (is_windows) windows.ws2_32.AI else std.c.AI;
         const ai: AI = .{};
+        const nc = ai.NUMERICSERV;
+        @memset(&ai, 0);
+        ai.NUMERICSERV = nc;
+
+        const AI_NUMERICSERV: i32 = ai;
 
         const name_c = try allocator.dupeZ(u8, name);
         defer allocator.free(name_c);
@@ -1269,7 +1274,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         defer allocator.free(port_c);
 
         const hints = addrinfo{
-            .flags = ai.NUMERICSERV,
+            .flags = AI_NUMERICSERV,
             .family = std.posix.AF.UNSPEC,
             .socktype = std.posix.SOCK.STREAM,
             .protocol = std.posix.IPPROTO.TCP,

--- a/network.zig
+++ b/network.zig
@@ -1259,7 +1259,7 @@ pub fn getEndpointList(allocator: std.mem.Allocator, name: []const u8, port: u16
         const freeaddrinfo_fn = if (is_windows) windows.funcs.freeaddrinfo else std.posix.system.freeaddrinfo;
         const addrinfo = if (is_windows) windows.addrinfo else std.posix.addrinfo;
 
-        const AI_NUMERICSERV = if (is_windows)
+        const AI_NUMERICSERV: bool = if (is_windows)
             windows.ws2_32.AI.NUMERICSERV
         else
             std.c.AI.NUMERICSERV;

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -15,13 +15,13 @@ test "Get endpoint list" {
     }
 }
 
-const host = "tcpbin.com";
-
 test "Connect to an echo server" {
+    const test_host = "tcpbin.com";
+
     try network.init();
     defer network.deinit();
 
-    const sock = try network.connectToHost(std.testing.allocator, host, 4242, .tcp);
+    const sock = try network.connectToHost(std.testing.allocator, test_host, 4242, .tcp);
     defer sock.close();
 
     const msg = "Hi from socket!\n";
@@ -34,12 +34,14 @@ test "Connect to an echo server" {
 }
 
 test "Echo server readiness" {
+    const test_host = "tcpbin.com";
+
     try network.init();
     defer network.deinit();
 
     const sock = try network.connectToHost(
         std.testing.allocator,
-        host,
+        test_host,
         4242,
         .tcp,
     );

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -19,7 +19,8 @@ test "Connect to an echo server" {
     try network.init();
     defer network.deinit();
 
-    const sock = try network.connectToHost(std.testing.allocator, "tcpbin.com", 4242, .tcp);
+    const host = "45.79.112.203"; //"tcpbin.com";
+    const sock = try network.connectToHost(std.testing.allocator, host, 4242, .tcp);
     defer sock.close();
 
     const msg = "Hi from socket!\n";

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -15,11 +15,12 @@ test "Get endpoint list" {
     }
 }
 
+const host = "tcpbin.com";
+
 test "Connect to an echo server" {
     try network.init();
     defer network.deinit();
 
-    const host = "45.79.112.203"; //"tcpbin.com";
     const sock = try network.connectToHost(std.testing.allocator, host, 4242, .tcp);
     defer sock.close();
 
@@ -38,7 +39,7 @@ test "Echo server readiness" {
 
     const sock = try network.connectToHost(
         std.testing.allocator,
-        "tcpbin.com",
+        host,
         4242,
         .tcp,
     );


### PR DESCRIPTION
this pr fixes #92 

- fixed compilation for zig0.14.0 (actually for linux - zig-linux-x86_64-**0.14.0-dev**.1694+3b465ebec)
- unmaintained *goto-bus-stop/setup-zig* was replaced with **mlugg/setup-zig**