### PR TITLE
Fix  Darwin: connection-mode socket was connected already #69 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           version: master
 
+      - name: Compile and run testsuite
+        run: |
+          zig build test
+
       - name: Compile and test synchronous
         run: |
           zig build test install sync-examples

--- a/network.zig
+++ b/network.zig
@@ -751,7 +751,7 @@ pub const Socket = struct {
             return std.posix.sendto(sockfd, buf, flags, dest_addr, addrlen);
         }
         while (true) {
-            const rc = std.posix.system.sendto(sockfd, buf, flags, dest_addr, addrlen);
+            const rc = std.posix.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
             switch (std.posix.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
 

--- a/network.zig
+++ b/network.zig
@@ -737,7 +737,9 @@ pub const Socket = struct {
 
         return len;
     }
-
+    // .darwin returns ISCONN error for already connected socket
+    // .windows and .lynux both don't care
+    // Intercepts ISCONN status for .darwin and retry sendto with null destination address
     pub fn sendto(
         /// The file descriptor of the sending socket.
         sockfd: std.posix.socket_t,

--- a/network.zig
+++ b/network.zig
@@ -747,7 +747,7 @@ pub const Socket = struct {
         dest_addr: ?*const std.posix.sockaddr,
         addrlen: std.posix.socklen_t,
     ) std.posix.SendToError!usize {
-        if ((builtin.tag.native_os == .windows) or (builtin.tag.native_os == .linux)) {
+        if (!is_darwin) {
             return std.posix.sendto(sockfd, buf, flags, dest_addr, addrlen);
         }
         while (true) {

--- a/network.zig
+++ b/network.zig
@@ -752,7 +752,7 @@ pub const Socket = struct {
         }
         while (true) {
             const rc = std.posix.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
-            switch (std.system.errno(rc)) {
+            switch (std.posix.system.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
 
                 .ACCES => return error.AccessDenied,
@@ -783,7 +783,7 @@ pub const Socket = struct {
                 .NETUNREACH => return error.NetworkUnreachable,
                 .NOTCONN => return error.SocketNotConnected,
                 .NETDOWN => return error.NetworkSubsystemFailed,
-                else => |err| return std.posix.system.unexpectedErrno(err),
+                else => |err| return std.posix.unexpectedErrno(err),
             }
         }
     }

--- a/network.zig
+++ b/network.zig
@@ -751,7 +751,7 @@ pub const Socket = struct {
             return std.posix.sendto(sockfd, buf, flags, dest_addr, addrlen);
         }
         while (true) {
-            const rc = std.posix.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
+            const rc = std.posix.system.sendto(sockfd, buf, flags, dest_addr, addrlen);
             switch (std.posix.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
 
@@ -767,7 +767,7 @@ pub const Socket = struct {
                 .INVAL => return error.UnreachableAddress,
                 // connection-mode socket was connected already but a recipient was specified
                 // sendto using NULL destination address
-                .ISCONN => return std.posix.sendto(sockfd, buf.ptr, buf.len, flags, null, 0),
+                .ISCONN => return std.posix.sendto(sockfd, buf, flags, null, 0),
                 .MSGSIZE => return error.MessageTooBig,
                 .NOBUFS => return error.SystemResources,
                 .NOMEM => return error.SystemResources,

--- a/network.zig
+++ b/network.zig
@@ -751,7 +751,7 @@ pub const Socket = struct {
             return std.posix.sendto(sockfd, buf, flags, dest_addr, addrlen);
         }
         while (true) {
-            const rc = std.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
+            const rc = std.posix.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
             switch (std.system.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
 
@@ -783,7 +783,7 @@ pub const Socket = struct {
                 .NETUNREACH => return error.NetworkUnreachable,
                 .NOTCONN => return error.SocketNotConnected,
                 .NETDOWN => return error.NetworkSubsystemFailed,
-                else => |err| return std.system.unexpectedErrno(err),
+                else => |err| return std.posix.system.unexpectedErrno(err),
             }
         }
     }

--- a/network.zig
+++ b/network.zig
@@ -752,7 +752,7 @@ pub const Socket = struct {
         }
         while (true) {
             const rc = std.posix.system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
-            switch (std.posix.system.errno(rc)) {
+            switch (std.posix.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
 
                 .ACCES => return error.AccessDenied,

--- a/network.zig
+++ b/network.zig
@@ -719,14 +719,14 @@ pub const Socket = struct {
         const saddr = receiver.toSocketAddress();
 
         const len = switch (saddr) {
-            .ipv4 => |sockaddr| try std.posix.sendto(
+            .ipv4 => |sockaddr| try sendto(
                 self.internal,
                 data,
                 flags,
                 @ptrCast(&sockaddr),
                 @sizeOf(@TypeOf(sockaddr)),
             ),
-            .ipv6 => |sockaddr| try std.posix.sendto(
+            .ipv6 => |sockaddr| try sendto(
                 self.internal,
                 data,
                 flags,

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const network = @import("network.zig");
+const network = @import("network");
 const expect = std.testing.expect;
 
 test "Get endpoint list" {
@@ -301,5 +301,6 @@ test "Darwin: connection-mode socket was connected already" {
     var buff: [128]u8 = undefined;
     _ = try sock.send(buff[0..]);
 
+    std.debug.print("Darwin: connection-mode socket test - finished\n", .{});
     return;
 }

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -246,7 +246,6 @@ test "parse + json parse" {
 
 test "Darwin: connection-mode socket was connected already" {
     const port: u16 = 12345;
-
     const Server = struct {
         const Self = @This();
         port: u16 = port,


### PR DESCRIPTION
this pr fixes #69 

- added test for the case
- intercepts **ISCONN** status returned by *.darwin* and retries sendto with null destination address

