### PR TITLE
fix: ipv6 parse in EndPoint

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -376,7 +376,7 @@ pub const EndPoint = struct {
     port: u16, // Stored as native, will convert to bigEndian when moving to sockaddr
 
     pub fn parse(string: []const u8) !EndPoint {
-        const colon_index = std.mem.indexOfScalar(u8, string, ':') orelse return error.InvalidFormat;
+        const colon_index = std.mem.lastIndexOfScalar(u8, string, ':') orelse return error.InvalidFormat;
 
         const address = try Address.parse(string[0..colon_index]);
 

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -219,7 +219,8 @@ test "parse + json parse" {
         \\{
         \\  "ipv4": "127.0.0.1",
         \\  "address": "10.0.0.1",
-        \\  "endpoint": "8.8.4.4:53"
+        \\  "endpoint": "8.8.4.4:53",
+        \\  "ipv6_endpoint": "::1:53"
         \\}
     ;
 
@@ -227,6 +228,7 @@ test "parse + json parse" {
         ipv4: network.Address.IPv4,
         address: network.Address,
         endpoint: network.EndPoint,
+        ipv6_endpoint: network.EndPoint,
     };
 
     const wrapper = try std.json.parseFromSliceLeaky(
@@ -242,6 +244,13 @@ test "parse + json parse" {
         .address = .{ .ipv4 = network.Address.IPv4.init(8, 8, 4, 4) },
         .port = 53,
     }, wrapper.endpoint);
+
+    var expected_addr = network.Address.IPv6.init(.{0} ** 16, 0);
+    expected_addr.value[15] = 1;
+    try std.testing.expectEqual(network.EndPoint{
+        .address = .{ .ipv6 = expected_addr },
+        .port = 53,
+    }, wrapper.ipv6_endpoint);
 }
 
 test "Darwin: connection-mode socket was connected already" {
@@ -284,7 +293,6 @@ test "Darwin: connection-mode socket was connected already" {
             srv.thread.join();
         }
     };
-
 
     var srv: Server = .{};
     try srv.start();


### PR DESCRIPTION
Thanks for the great work!

I just found the EndPoint couldn't parse IPv6 address properly because the position of colons. And created a simple fix.