### PR TITLE
Changes for zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,65 +9,81 @@ pub fn build(b: *std.Build) !void {
     });
 
     var test_runner = b.addTest(.{
-        .root_source_file = b.path("testsuite.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("testsuite.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     test_runner.root_module.addImport("network", module);
 
     const async_example = b.addExecutable(.{
         .name = "async",
-        .root_source_file = b.path("examples/async.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/async.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     async_example.root_module.addImport("network", module);
 
     const echo_example = b.addExecutable(.{
         .name = "echo",
-        .root_source_file = b.path("examples/echo.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/echo.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     echo_example.root_module.addImport("network", module);
 
     const udp_example = b.addExecutable(.{
         .name = "udp",
-        .root_source_file = b.path("examples/multicast_udp.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/multicast_udp.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     udp_example.root_module.addImport("network", module);
 
     const udp_broadcast_example = b.addExecutable(.{
         .name = "udp_broadcast",
-        .root_source_file = b.path("examples/udp_broadcast.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/udp_broadcast.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     udp_broadcast_example.root_module.addImport("network", module);
 
     const discovery_client = b.addExecutable(.{
         .name = "discovery_client",
-        .root_source_file = b.path("examples/discovery/client.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/discovery/client.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     discovery_client.root_module.addImport("network", module);
 
     const discovery_server = b.addExecutable(.{
         .name = "discovery_server",
-        .root_source_file = b.path("examples/discovery/server.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/discovery/server.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     discovery_server.root_module.addImport("network", module);
 
     const ntp_client = b.addExecutable(.{
         .name = "ntp_client",
-        .root_source_file = b.path("examples/ntp_client.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/ntp_client.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     ntp_client.root_module.addImport("network", module);
 

--- a/examples/ntp_client.zig
+++ b/examples/ntp_client.zig
@@ -5,32 +5,41 @@ const debug = std.debug;
 pub fn main() !void {
     try network.init();
     defer network.deinit();
-    var request: [48]u8 = std.mem.zeroes([48]u8);
-    request[0] = 0b00100011; // NTP version 4, mode 3 (client)
+
+    const request = std.mem.zeroInit(NtpHeader, .{
+        .flags = .{ .mode = .client },
+    });
 
     var sock = try network.connectToHost(std.heap.page_allocator, "pool.ntp.org", 123, .udp);
     defer sock.close();
 
-    try sock.writer().writeAll(&request);
+    try sock.writer().writeStructEndian(request, .big);
 
-    var response: [48]u8 = undefined;
-    _ = try sock.reader().readAll(&response);
+    const response: NtpHeader = try sock.reader().readStructEndian(NtpHeader, .big);
 
-    // The timestamp is stored in bytes 40-43 of the response
-    const seconds = @divFloor(std.time.milliTimestamp(), std.time.ms_per_s);
+    std.log.info("NTP Response:", .{});
+    std.log.info("  flags > version        = {}", .{response.flags.version});
+    std.log.info("  flags > mode           = .{s}", .{@tagName(response.flags.mode)});
+    std.log.info("  flags > leap indicator = .{s}", .{@tagName(response.flags.leap_indicator)});
+    std.log.info("  peer clock stratum     = .{s}", .{@tagName(response.peer_clock_stratum)});
+    std.log.info("  polling interval       = {}", .{response.polling_interval});
+    std.log.info("  peer clock precision   = {}", .{response.peer_clock_precision});
+    std.log.info("  root delay             = {d}", .{response.root_delay});
+    std.log.info("  root dispersion        = {d}", .{response.root_dispersion});
+    std.log.info("  reference id           = {d}", .{response.reference_id});
+    std.log.info("  reference timestamp    = {d}", .{response.reference_timestamp});
+    std.log.info("  origin timestamp       = {d}", .{response.origin_timestamp});
+    std.log.info("  receive timestamp      = {d}", .{response.receive_timestamp});
+    std.log.info("  transmit timestamp     = {d}", .{response.transmit_timestamp});
+    std.log.info("", .{});
 
-    // zig fmt: off
-    const fractionalSeconds = @as(u64, @intCast(response[40])) << 24
-    | @as(u64, @intCast(response[41])) << 16
-    | @as(u64, @intCast(response[42])) << 8
-    | @as(u64, @intCast(response[43]));
-    
-    const timestamp = @divFloor(seconds, 2_208_988_800) * std.time.ms_per_s + fractionalSeconds * (std.time.ns_per_s / 4_294_967_296);
+    // 1 Jan 1970
+    const unix_epoch_in_ntp_epoch = 2_208_988_800; //  First day UNIX
 
-    debug.print("NTP timestamp: {}\n", .{timestamp}); //0
+    const unix_timestamp = response.transmit_timestamp.seconds -| unix_epoch_in_ntp_epoch;
 
-    // result: 1970 -1 -1  0: 0: 0 (UTC 1970-01-01)
-    debug.print("{s}\n", .{try convertTimestampToTime(@as(u64, @intCast(timestamp)))});
+    var buf: [80:0]u8 = undefined;
+    std.log.info("UNIX UTC timestamp: {s}", .{try convertTimestampToTime(&buf, unix_timestamp)});
 }
 
 pub const secs_per_day: u17 = 24 * 60 * 60;
@@ -47,13 +56,134 @@ pub const EpochSeconds = struct {
     }
 };
 
-pub fn convertTimestampToTime(timestamp: u64) ![]const u8 {
+pub fn convertTimestampToTime(buf: []u8, timestamp: u64) ![]const u8 {
     const epochSeconds = EpochSeconds{ .secs = timestamp };
     const epochDay = epochSeconds.getEpochDay();
     const daySeconds = epochSeconds.getDaySeconds();
     const yearDay = epochDay.calculateYearDay();
     const monthDay = yearDay.calculateMonthDay();
-    var buf: [80:0]u8 = undefined;
 
-    return std.fmt.bufPrint(&buf, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", .{ yearDay.year, monthDay.month.numeric(), monthDay.day_index + 1, daySeconds.getHoursIntoDay(), daySeconds.getMinutesIntoHour(), daySeconds.getSecondsIntoMinute() });
+    return std.fmt.bufPrint(buf, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", .{ yearDay.year, monthDay.month.numeric(), monthDay.day_index + 1, daySeconds.getHoursIntoDay(), daySeconds.getMinutesIntoHour(), daySeconds.getSecondsIntoMinute() });
 }
+
+comptime {
+    std.debug.assert(@sizeOf(NtpHeader) == 48);
+}
+pub const NtpHeader = extern struct {
+    const Flags = packed struct(u8) {
+        mode: enum(u3) {
+            reserved = 0,
+            symmetric_active = 1,
+            symmetric_passive = 2,
+            client = 3,
+            server = 4,
+            broadcast = 5,
+            ntp_control_message = 6,
+            reserved_for_private_use = 7,
+        },
+        version: u3 = 4,
+        leap_indicator: enum(u2) {
+            no_warning = 0,
+            /// last minute of the day has 61 seconds
+            last_minute_61 = 1,
+            /// last minute of the day has 59 seconds
+            last_minute_59 = 2,
+            /// unknown (clock unsynchronized)
+            unknown = 3,
+        } = .unknown,
+    };
+    flags: Flags,
+    peer_clock_stratum: enum(u8) {
+        unspecified = 0, // unspecified or invalid
+        primary_server = 1, // primary server (e.g., equipped with a GPS receiver)
+        secondary_server_0 = 2, // secondary server (via NTP)
+        secondary_server_1 = 3, // secondary server (via NTP)
+        secondary_server_2 = 4, // secondary server (via NTP)
+        secondary_server_3 = 5, // secondary server (via NTP)
+        secondary_server_4 = 6, // secondary server (via NTP)
+        secondary_server_5 = 7, // secondary server (via NTP)
+        secondary_server_6 = 8, // secondary server (via NTP)
+        secondary_server_7 = 9, // secondary server (via NTP)
+        secondary_server_8 = 10, // secondary server (via NTP)
+        secondary_server_9 = 11, // secondary server (via NTP)
+        secondary_server_10 = 12, // secondary server (via NTP)
+        secondary_server_11 = 13, // secondary server (via NTP)
+        secondary_server_12 = 14, // secondary server (via NTP)
+        secondary_server_13 = 15, // secondary server (via NTP)
+        unsynchronized = 16,
+        _, // 17 .. 255 reserved
+    },
+
+    /// Poll: 8-bit signed integer representing the maximum interval between
+    /// successive messages, in log2 seconds.  Suggested default limits for
+    /// minimum and maximum poll intervals are 6 and 10, respectively.
+    polling_interval: i8,
+
+    /// Precision: 8-bit signed integer representing the precision of the
+    /// system clock, in log2 seconds.  For instance, a value of -18
+    /// corresponds to a precision of about one microsecond.  The precision
+    /// can be determined when the service first starts up as the minimum
+    /// time of several iterations to read the system clock.
+    peer_clock_precision: i8,
+
+    // Root Delay (rootdelay): Total round-trip delay to the reference clock, in NTP short format.
+    root_delay: NtpShort,
+
+    // Root Dispersion (rootdisp): Total dispersion to the reference clock, in NTP short format.
+    root_dispersion: NtpShort,
+
+    /// 32-bit code identifying the particular server
+    /// or reference clock.  The interpretation depends on the value in the
+    /// stratum field.
+    reference_id: u32,
+
+    /// Reference Timestamp: Time when the system clock was last set or
+    /// corrected, in NTP timestamp format.
+    reference_timestamp: NtpTimestamp,
+
+    /// Origin Timestamp (org): Time at the client when the request departed
+    /// for the server, in NTP timestamp format.
+    origin_timestamp: NtpTimestamp,
+
+    /// Receive Timestamp (rec): Time at the server when the request arrived
+    /// from the client, in NTP timestamp format.
+    receive_timestamp: NtpTimestamp,
+
+    /// Transmit Timestamp (xmt): Time at the server when the response left
+    /// for the client, in NTP timestamp format.
+    transmit_timestamp: NtpTimestamp,
+};
+
+const NtpShort = packed struct(u32) {
+    seconds: u16,
+    fraction: u16,
+
+    pub fn get_seconds(ts: NtpShort) f32 {
+        const secs: f32 = @floatFromInt(ts.seconds);
+        const frac: f32 = @floatFromInt(ts.fraction);
+
+        return secs + frac / std.math.maxInt(u16);
+    }
+
+    pub fn format(ts: NtpShort, comptime fmt: []const u8, opt: std.fmt.FormatOptions, writer: anytype) !void {
+        try std.fmt.formatType(ts.get_seconds(), fmt, opt, writer, 1);
+    }
+};
+
+/// In the date and timestamp formats, the prime epoch, or base date of
+/// era 0, is 0 h 1 January 1900 UTC, when all bits are zero.
+const NtpTimestamp = extern struct {
+    seconds: u32,
+    fraction: u32,
+
+    pub fn get_seconds(ts: NtpTimestamp) f64 {
+        const secs: f64 = @floatFromInt(ts.seconds);
+        const frac: f64 = @floatFromInt(ts.fraction);
+
+        return secs + frac / std.math.maxInt(u32);
+    }
+
+    pub fn format(ts: NtpTimestamp, comptime fmt: []const u8, opt: std.fmt.FormatOptions, writer: anytype) !void {
+        try std.fmt.formatType(ts.get_seconds(), fmt, opt, writer, 1);
+    }
+};

--- a/network.zig
+++ b/network.zig
@@ -1470,11 +1470,11 @@ const windows = struct {
     };
 
     const funcs = struct {
-        extern "ws2_32" fn recvfrom(s: ws2_32.SOCKET, buf: [*c]u8, len: c_int, flags: c_int, from: [*c]std.posix.sockaddr, fromlen: [*c]std.posix.socklen_t) callconv(std.os.windows.WINAPI) c_int;
-        extern "ws2_32" fn select(nfds: c_int, readfds: ?*anyopaque, writefds: ?*anyopaque, exceptfds: ?*anyopaque, timeout: [*c]const timeval) callconv(std.os.windows.WINAPI) c_int;
+        extern "ws2_32" fn recvfrom(s: ws2_32.SOCKET, buf: [*c]u8, len: c_int, flags: c_int, from: [*c]std.posix.sockaddr, fromlen: [*c]std.posix.socklen_t) callconv(std.builtin.CallingConvention.winapi) c_int;
+        extern "ws2_32" fn select(nfds: c_int, readfds: ?*anyopaque, writefds: ?*anyopaque, exceptfds: ?*anyopaque, timeout: [*c]const timeval) callconv(std.builtin.CallingConvention.winapi) c_int;
         extern "ws2_32" fn __WSAFDIsSet(arg0: ws2_32.SOCKET, arg1: [*]u8) c_int;
-        extern "ws2_32" fn getaddrinfo(nodename: [*:0]const u8, servicename: [*:0]const u8, hints: *const posix.addrinfo, result: **posix.addrinfo) callconv(std.os.windows.WINAPI) c_int;
-        extern "ws2_32" fn freeaddrinfo(res: *posix.addrinfo) callconv(std.os.windows.WINAPI) void;
+        extern "ws2_32" fn getaddrinfo(nodename: [*:0]const u8, servicename: [*:0]const u8, hints: *const posix.addrinfo, result: **posix.addrinfo) callconv(std.builtin.CallingConvention.winapi) c_int;
+        extern "ws2_32" fn freeaddrinfo(res: *posix.addrinfo) callconv(std.builtin.CallingConvention.winapi) void;
     };
 
     // TODO: This can be removed in favor of upstream Zig `std.posix.socket` if the

--- a/network.zig
+++ b/network.zig
@@ -478,8 +478,8 @@ pub const Socket = struct {
     pub const SendError = (std.posix.SendError || std.posix.SendToError);
     pub const ReceiveError = std.posix.RecvFromError;
 
-    pub const Reader = std.io.Reader(Socket, ReceiveError, receive);
-    pub const Writer = std.io.Writer(Socket, SendError, send);
+    pub const Reader = std.io.GenericReader(Socket, ReceiveError, receive);
+    pub const Writer = std.io.GenericWriter(Socket, SendError, send);
 
     const Self = @This();
 


### PR DESCRIPTION
Hey, first of all shoutout and a big thank you for zig-network 🙏🏽!

I'm using it to implement [zig-osc](https://github.com/guidoschmidt/zig-osc), a zig implementation of the [Open Sound Control](https://opensoundcontrol.stanford.edu/index.html) standard. It somehow started as a toy project for learning zig, but now somewhat starts to become really usable. Anyway, I started migrating it to zig 0.15.1 yesterday and realised upstream also needs some adjustments. So I gave it a go.

So far, I've only touched `network.zig`, none of the examples. I'm going to have a look into these as well later.

Most of it was straight forward, only I'm not sure about the new `std.io.Writer` and `std.io.Reader` stuff, changing it to [`std.io.GenericReader`/`std.io.GenericWriter`](https://github.com/ikskuh/zig-network/commit/31ace69249dc0dbfd6d75aabe3af02d2f7d9c6e2) seems to work perfectly well though.